### PR TITLE
Task class: add assert statements in deserialize

### DIFF
--- a/src/main/java/com/elsria/task/Task.java
+++ b/src/main/java/com/elsria/task/Task.java
@@ -139,19 +139,27 @@ public abstract class Task {
         }
 
         return switch (taskType) {
-        case TODO -> new ToDoTask(
-                tokens[2],
-                Integer.parseInt(tokens[1]) != 0);
-        case DEADLINE -> new DeadlineTask(
+        case TODO:
+            assert tokens.length == 3;
+            yield new ToDoTask(
+                    tokens[2],
+                    Integer.parseInt(tokens[1]) != 0
+            );
+        case DEADLINE:
+            assert tokens.length == 4;
+            yield new DeadlineTask(
                 tokens[2],
                 Time.parseTime(tokens[3]),
-                Integer.parseInt(tokens[1]) != 0);
-        case EVENT -> new EventTask(
+                Integer.parseInt(tokens[1]) != 0
+            );
+        case EVENT:
+            assert tokens.length == 5;
+            yield new EventTask(
                 tokens[2],
                 Time.deserialize(tokens[3]),
                 Time.deserialize(tokens[4]),
                 Integer.parseInt(tokens[1]) != 0
-        );
+            );
         };
     }
 


### PR DESCRIPTION
Deserialize method just assumes that the correct
number of arguments are provided to correctly
deserialize and create a new Task

This could result in Array Access issues if
the number of tokens is not equal to the
number of arguments needed to create the
new task.

Adding assert statements at least emphasizes
how many tokens should the deserialized String
should have in order to create the Task.

Let's add assert statements to the deserialization
function in the Task class before Task creation.